### PR TITLE
Move fonts.less from Khan/KaTeX

### DIFF
--- a/fonts.less
+++ b/fonts.less
@@ -1,0 +1,63 @@
+@font-folder: "fonts";
+@use-ttf: true;
+@use-woff: true;
+@use-woff2: true;
+
+.use-woff2(@family, @family-suffix) when (@use-woff2 = true) {
+    src+: url('@{font-folder}/KaTeX_@{family}-@{family-suffix}.woff2') format('woff2')
+}
+
+.use-woff(@family, @family-suffix) when (@use-woff = true) {
+    src+: url('@{font-folder}/KaTeX_@{family}-@{family-suffix}.woff') format('woff')
+}
+
+.use-ttf(@family, @family-suffix) when (@use-ttf = true) {
+    src+: url('@{font-folder}/KaTeX_@{family}-@{family-suffix}.ttf') format('truetype')
+}
+
+.generate-suffix(@weight, @style) when (@weight = normal) and (@style = normal) {
+    @suffix: 'Regular';
+}
+.generate-suffix(@weight, @style) when (@weight = normal) and (@style = italic) {
+    @suffix: 'Italic';
+}
+.generate-suffix(@weight, @style) when (@weight = bold) and (@style = normal) {
+    @suffix: 'Bold';
+}
+.generate-suffix(@weight, @style) when (@weight = bold) and (@style = italic) {
+    @suffix: 'BoldItalic';
+}
+
+.font-face(@family, @weight, @style) {
+    .generate-suffix(@weight, @style);
+    @font-face {
+        font-family: 'KaTeX_@{family}';
+        .use-woff2(@family, @suffix);
+        .use-woff(@family, @suffix);
+        .use-ttf(@family, @suffix);
+        font-weight: @weight;
+        font-style: @style;
+    }
+}
+
+.font-face('AMS', normal, normal);
+.font-face('Caligraphic', bold, normal);
+.font-face('Caligraphic', normal, normal);
+.font-face('Fraktur', bold, normal);
+.font-face('Fraktur', normal, normal);
+.font-face('Main', bold, normal);
+.font-face('Main', bold, italic);
+.font-face('Main', normal, italic);
+.font-face('Main', normal, normal);
+// .font-face('Math', bold, italic);
+.font-face('Math', normal, italic);
+// .font-face('Math', normal, normal);
+.font-face('SansSerif', bold, normal);
+.font-face('SansSerif', normal, italic);
+.font-face('SansSerif', normal, normal);
+.font-face('Script', normal, normal);
+.font-face('Size1', normal, normal);
+.font-face('Size2', normal, normal);
+.font-face('Size3', normal, normal);
+.font-face('Size4', normal, normal);
+.font-face('Typewriter', normal, normal);


### PR DESCRIPTION
Summary:
This will allow us to remove the symlink from Khan/KaTeX to
this repo's font folder without changing any of the paths in
fonts.less.

Test Plan:
- npm run prepublishOnly (in Khan/KaTeX)
- see that it puts the fonts in the correct folders in build