### PR TITLE
Improve fonts generation: enable CircleCI to build Docker image and fonts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: $DOCKER_USERNAME/katex-fonts:29d4cdbc
+
+    steps:
+      - checkout
+
+      - run:
+          name: Build fonts
+          command: |
+            cd src
+            cp default.cfg custom.cfg
+            make custom.cfg.pl
+            make -C fonts/OTF/TeX ttf woff woff2
+            cd ..
+            rm -f fonts/*.*
+            cp src/fonts/OTF/TeX/ttf/*.ttf fonts
+            cp src/fonts/OTF/TeX/woff/*.woff fonts
+            cp src/fonts/OTF/TeX/woff2/*.woff2 fonts
+            tar zcf fonts.tar.gz fonts
+
+      - run:
+          name: Build metrics
+          command: ./buildMetrics.sh
+
+      - store_artifacts:
+          path: fonts.tar.gz
+          destination: fonts.tar.gz
+
+      - store_artifacts:
+          path: fontMetricsData.js
+          destination: fontMetricsData.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+## To update `Dockerfile`
+1. Checkout `docker` branch and edit `Dockerfile`
+2. Send a PR against `docker` branch
+3. If the PR is merged, CircleCI builds and pushes the Docker image
+4. Checkout `master` branch and update `Dockerfile` and Docker image tag in `.circleci/config.yml`
+5. Send a PR against `master` branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update \
     pkg-config \
     libharfbuzz-dev \
     libfreetype6-dev \
+    libjson-perl \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && gem install ttfunk --version 1.1.1


### PR DESCRIPTION
This PR is part of #12.

I think it's best to have another branch for `Dockerfile` and CircleCI configs to build the image. I've pushed the branch to https://github.com/KaTeX/katex-fonts/tree/docker:

https://github.com/KaTeX/katex-fonts/blob/8d0cfd857bfb105c6cfc9e785ffc6cd4b448cd73/.circleci/config.yml#L1-L19

**Example CircleCI builds:** [`docker` branch](https://circleci.com/gh/ylemkimon/katex-fonts/16), [PR branch](https://circleci.com/gh/ylemkimon/katex-fonts/18)

- [ ] Enable CircleCI on the repo
- [ ] Set Docker username and password as `DOCKER_USERNAME` and `DOCKER_PASSWORD`, respectively, in the environment variables